### PR TITLE
Fix issue with webcorevitals breaking this extension

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -82,6 +82,9 @@ const get = (obj, path, def) => {
 if (dataLayer && gtmId) {
   // Get object from dataLayer that matches the gtm.uniqueEventId
   let obj = dataLayer.map(o => {
+    //add additional check for values not supported by copyFromWindow
+    if (!o) return {};
+    
     // If a regular dataLayer object, return it
     if (o['gtm.uniqueEventId']) return o;
     // Other wise assume it's a template constructor-based object


### PR DESCRIPTION
On a webcorevital event from the simo ahava GTM template, the copyFromWindow returns a undefined object.
As a result, the current code fails at this line
`    if (o['gtm.uniqueEventId']) return o;`
I have introduced a check at the beginning of the map function to prevent errors from happening.